### PR TITLE
fix(posts): Fix model migration down

### DIFF
--- a/database/migrations/2018_06_22_111322_create_posts_db.php
+++ b/database/migrations/2018_06_22_111322_create_posts_db.php
@@ -78,9 +78,10 @@ class CreatePostsDb extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('posts_data');
         Schema::dropIfExists('posts_labels');
-        Schema::dropIfExists('posts_authors');
         Schema::dropIfExists('posts_images');
+        Schema::dropIfExists('posts_authors');
+        Schema::dropIfExists('posts_data');
+        Schema::drofIfExists('posts_pivot_labels_data');
     }
 }

--- a/database/migrations/2018_06_22_111322_create_posts_db.php
+++ b/database/migrations/2018_06_22_111322_create_posts_db.php
@@ -78,10 +78,12 @@ class CreatePostsDb extends Migration
      */
     public function down()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::dropIfExists('posts_labels');
         Schema::dropIfExists('posts_images');
         Schema::dropIfExists('posts_authors');
         Schema::dropIfExists('posts_data');
-        Schema::drofIfExists('posts_pivot_labels_data');
+        Schema::dropIfExists('posts_pivot_labels_data');
+        Schema::enableForeignKeyConstraints();
     }
 }


### PR DESCRIPTION
- Added "Schema::drofIfExists('posts_pivot_labels_data');" to
database/migrations/2018_06_22_111322_create_posts_db.php
- re-ordered dropIfExists calls to the order tables were created

fixes #13