### PR TITLE
Issue82: TestsBase->checkCaching()

### DIFF
--- a/tests/Feature/CanteenAPITest.php
+++ b/tests/Feature/CanteenAPITest.php
@@ -55,22 +55,11 @@ class CanteenAPITest extends TestCase
         } else {
             $validResp = array($this->meal->setHidden(['canteens', 'created_at', 'updated_at'])->toArray());
         
-            $farDate = 'Mon, 4 Jan 2100 00:00:00 GMT';
-            $oldDate = 'Mon, 5 Jan 1970 00:00:00 GMT';
-        
-            // Valid request
+            // Valid request, no data alaviable
             $response = $this->API($endpoint, 'id=1');
             $this->assertValidResponse($response, $validResp);
-            
-            // Valid request with if-mod-since header
-            // (new data)
-            $response = $this->API($endpoint, 'id=1', ['If-modified-since'=>$oldDate]);
-            $this->assertValidResponse($response, $validResp);
-            
-            // Valid request with if-mod-since header
-            // (not modified)
-            $response = $this->API($endpoint, 'id=1', ['If-modified-since'=>$farDate]);
-            $this->checkResponseCode($response, 304);
+        
+            $this->checkCaching($endpoint, 'id=1');
         }
     }
     
@@ -93,22 +82,12 @@ class CanteenAPITest extends TestCase
             
             $validResponse = array($this->canteen->setHidden(['date', 'created_at', 'updated_at'])->toArray());
             
-            $farDate = 'Mon, 4 Jan 2100 00:00:00';
-            $oldDate = 'Mon, 5 Jan 1970 00:00:00';
             
             // Valid request
-            $response = $this->API($endpoint, 'year='.$year.'&week='.$week);
+            $response = $this->API($endpoint, "year=$year&week=$week");
             $this->assertValidResponse($response, $validResponse);
             
-            // Valid request with if-mod-since header
-            // (new data)
-            $response = $this->API($endpoint, 'year='.$year.'&week='.$week, ['If-modified-since'=>$oldDate]);
-            $this->assertValidResponse($response, $validResponse);
-            
-            // Valid request with if-mod-since header
-            // (not modified)
-            $response = $this->API($endpoint, 'year='.$year.'&week='.$week, ['If-modified-since'=>$farDate]);
-            $this->checkResponseCode($response, 304);
+            $this->checkCaching($endpoint, "year=$year&week=$week");
         }
     }
     

--- a/tests/Feature/EventsAPITest.php
+++ b/tests/Feature/EventsAPITest.php
@@ -30,7 +30,7 @@ class EventsAPITest extends TestCase
         $month = $this->date->month;
         
         // Valid request
-        $response = $this->API($endpoint, 'year='.$year.'&month='.$month);
+        $response = $this->API($endpoint, "year=$year&month=$month");
         $this->assertValidResponse($response, $validResponse);
         
         // Invalid request
@@ -45,19 +45,7 @@ class EventsAPITest extends TestCase
         $response = $this->API($endpoint, 'year=1970&month=1');
         $this->checkResponseCode($response, 404);
         
-        $farDate = 'Mon, 4 Jan 2100 00:00:00';
-        $oldDate = 'Mon, 5 Jan 1970 00:00:00';
-        
-        
-        // Valid request with if-mod-since header
-        // (new data)
-        $response = $this->API($endpoint, 'year='.$year.'&month='.$month, ['If-modified-since'=>$oldDate]);
-        $this->assertValidResponse($response, $validResponse);
-            
-        // Valid request with if-mod-since header
-        // (not modified)
-        $response = $this->API($endpoint, 'year='.$year.'&month='.$month, ['If-modified-since'=>$farDate]);
-        $this->checkResponseCode($response, 304);
+        $this->checkCaching($endpoint, "year=$year&month=$month");
     }
     
     public function setupDB()

--- a/tests/Feature/PostsAPITest.php
+++ b/tests/Feature/PostsAPITest.php
@@ -62,18 +62,7 @@ class PostsAPITest extends TestCase
         $this->checkResponseCode($response, 404);
         
         
-        $farDate = 'Mon, 4 Jan 2100 00:00:00';
-        $oldDate = 'Mon, 5 Jan 1970 00:00:00';
-        
-        // Valid request with if-mod-since header
-        // (new data)
-        $response = $this->API($endpoint, '', ['If-modified-since'=>$oldDate]);
-        $this->assertValidResponse($response, $validResponse);
-            
-        // Valid request with if-mod-since header
-        // (not modified)
-        $response = $this->API($endpoint, '', ['If-modified-since'=>$farDate]);
-        $this->checkResponseCode($response, 304);
+        $this->checkCaching($endpoint);
     }
     
     public function byId()
@@ -97,18 +86,7 @@ class PostsAPITest extends TestCase
         $this->checkResponseCode($response, 404);
         
         
-        $farDate = 'Mon, 4 Jan 2100 00:00:00';
-        $oldDate = 'Mon, 5 Jan 1970 00:00:00';
-        
-        // Valid request with if-mod-since header
-        // (new data)
-        $response = $this->API($endpoint, 'id=1', ['If-modified-since'=>$oldDate]);
-        $this->assertValidResponse($response, $validResponse);
-            
-        // Valid request with if-mod-since header
-        // (not modified)
-        $response = $this->API($endpoint, 'id=1', ['If-modified-since'=>$farDate]);
-        $this->checkResponseCode($response, 304);
+        $this->checkCaching($endpoint, 'id=1');
     }
     
     public function byLabel()
@@ -132,18 +110,7 @@ class PostsAPITest extends TestCase
         $this->checkResponseCode($response, 404);
         
         
-        $farDate = 'Mon, 4 Jan 2100 00:00:00';
-        $oldDate = 'Mon, 5 Jan 1970 00:00:00';
-        
-        // Valid request with if-mod-since header
-        // (new data)
-        $response = $this->API($endpoint, 'id=1', ['If-modified-since'=>$oldDate]);
-        $this->assertValidResponse($response, $validResponse);
-            
-        // Valid request with if-mod-since header
-        // (not modified)
-        $response = $this->API($endpoint, 'id=1', ['If-modified-since'=>$farDate]);
-        $this->checkResponseCode($response, 304);
+        $this->checkCaching($endpoint, 'id=1');
     }
     
     public function byAuthor()
@@ -167,18 +134,7 @@ class PostsAPITest extends TestCase
         $this->checkResponseCode($response, 404);
         
         
-        $farDate = 'Mon, 4 Jan 2100 00:00:00';
-        $oldDate = 'Mon, 5 Jan 1970 00:00:00';
-        
-        // Valid request with if-mod-since header
-        // (new data)
-        $response = $this->API($endpoint, 'id=1', ['If-modified-since'=>$oldDate]);
-        $this->assertValidResponse($response, $validResponse);
-            
-        // Valid request with if-mod-since header
-        // (not modified)
-        $response = $this->API($endpoint, 'id=1', ['If-modified-since'=>$farDate]);
-        $this->checkResponseCode($response, 304);
+        $this->checkCaching($endpoint, 'id=1');
     }
     
     public function search()
@@ -204,18 +160,7 @@ class PostsAPITest extends TestCase
         $this->checkResponseCode($response, 404);
         
         
-        $farDate = 'Mon, 4 Jan 2100 00:00:00';
-        $oldDate = 'Mon, 5 Jan 1970 00:00:00';
-        
-        // Valid request with if-mod-since header
-        // (new data)
-        $response = $this->API($endpoint, "term=$searchTerm", ['If-modified-since'=>$oldDate]);
-        $this->assertValidResponse($response, $validResponse);
-            
-        // Valid request with if-mod-since header
-        // (not modified)
-        $response = $this->API($endpoint, "term=$searchTerm", ['If-modified-since'=>$farDate]);
-        $this->checkResponseCode($response, 304);
+        $this->checkCaching($endpoint, "term=$searchTerm");
     }
     
     public function setupDB()

--- a/tests/Feature/TestsBase.php
+++ b/tests/Feature/TestsBase.php
@@ -38,4 +38,20 @@ trait TestsBase
         $response->assertOk();
         $response->assertJson($content);
     }
+    
+    protected function checkCaching($endpoint, $params='')
+    {
+        $farDate = 'Mon, 4 Jan 2100 00:00:00';
+        $oldDate = 'Mon, 5 Jan 1970 00:00:00';
+        
+        // Valid request with if-mod-since header
+        // (new data)
+        $response = $this->API($endpoint, $params, ['If-modified-since'=>$oldDate]);
+        $response->assertOk();
+            
+        // Valid request with if-mod-since header
+        // (not modified)
+        $response = $this->API($endpoint, $params, ['If-modified-since'=>$farDate]);
+        $this->checkResponseCode($response, 304);
+    }
 }


### PR DESCRIPTION
If applied, this PR will add the `checkCaching($endpoint, $params)` method to `TestsBase` and refactor all tests to use it.
Closes #83, closes #82 