### PR TITLE
Fix: Remove line ending checking from php-cs-fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -12,6 +12,7 @@ return PhpCsFixer\Config::create()
         '@PSR1' => true,
         '@PSR2' => true,
         '@Symfony' => true,
+        'line_ending' => false,
     ])
     ->setFinder($finder)
 ;


### PR DESCRIPTION
This commit should remove line ending checking