### PR TITLE
Disable lists in MD parser

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Posts;
-use Parsedown;
+use App\Markdown;
 
 class PostsController extends Controller
 {
@@ -127,7 +127,7 @@ class PostsController extends Controller
         }
         assert(is_array($post));
 
-        $parser = Parsedown::instance()->setBreaksEnabled(true)->setMarkupEscaped(true)->setUrlsLinked(false);
+        $parser = Markdown::instance()->setBreaksEnabled(true)->setMarkupEscaped(true)->setUrlsLinked(false);
 
         $post['content'] = isset($post['content']) ? $parser->text($post['content']) : '';
 

--- a/app/Markdown.php
+++ b/app/Markdown.php
@@ -1,16 +1,19 @@
 <?php
+
 namespace App;
+
 use Parsedown;
 
 /**
-* Just an inherited parser with disabled lists.
-* Was needed because every article starts with a date 201x. xx. xx
-* And the parser made it a lsit
-* @author     Sasszem
-*/
+ * Just an inherited parser with disabled lists.
+ * Was needed because every article starts with a date 201x. xx. xx
+ * And the parser made it a list.
+ *
+ * @author     Sasszem
+ */
 class Markdown extends Parsedown
 {
-        protected $BlockTypes = array(
+    protected $BlockTypes = array(
         '#' => array('Header'),
         '*' => array('Rule', 'List'),
         '+' => array('List'),

--- a/app/Markdown.php
+++ b/app/Markdown.php
@@ -1,0 +1,28 @@
+<?php
+namespace App;
+use Parsedown;
+
+/**
+* Just an inherited parser with disabled lists.
+* Was needed because every article starts with a date 201x. xx. xx
+* And the parser made it a lsit
+* @author     Sasszem
+*/
+class Markdown extends Parsedown
+{
+        protected $BlockTypes = array(
+        '#' => array('Header'),
+        '*' => array('Rule', 'List'),
+        '+' => array('List'),
+        '-' => array('SetextHeader', 'Table', 'Rule', 'List'),
+        ':' => array('Table'),
+        '<' => array('Comment', 'Markup'),
+        '=' => array('SetextHeader'),
+        '>' => array('Quote'),
+        '[' => array('Reference'),
+        '_' => array('Rule'),
+        '`' => array('FencedCode'),
+        '|' => array('Table'),
+        '~' => array('FencedCode'),
+    );
+}


### PR DESCRIPTION
Posts start with a date like `20xx. yy. zz` & `Parsedown` interprets it as a numbered list.
Fixed by disabling numbered lists. 
Fixes #248